### PR TITLE
proposal(overlay): use flexbox for global positioning

### DIFF
--- a/src/lib/core/overlay/_overlay.scss
+++ b/src/lib/core/overlay/_overlay.scss
@@ -8,10 +8,7 @@
 
   // TODO(jelbourn): change from the `md` prefix to something else for everything in the toolkit.
 
-  // The overlay-container is an invisible element which contains all individual overlays.
-  .md-overlay-container {
-    position: fixed;
-
+  .md-overlay-container, .md-overlay-pane-wrapper {
     // Disable events from being captured on the overlay container.
     pointer-events: none;
 
@@ -20,7 +17,18 @@
     left: 0;
     height: 100%;
     width: 100%;
+  }
+
+  // The overlay-container is an invisible element which contains all individual overlays.
+  .md-overlay-container {
+    position: fixed;
     z-index: $md-z-index-overlay-container;
+  }
+
+  .md-overlay-pane-wrapper {
+    display: flex;
+    position: absolute;
+    z-index: $md-z-index-overlay;
   }
 
   // A single overlay pane.
@@ -28,7 +36,7 @@
     position: absolute;
     pointer-events: auto;
     box-sizing: border-box;
-    z-index: $md-z-index-overlay;
+    z-index: inherit;
   }
 
   .md-overlay-backdrop {

--- a/src/lib/core/overlay/overlay-ref.ts
+++ b/src/lib/core/overlay/overlay-ref.ts
@@ -17,7 +17,7 @@ export class OverlayRef implements PortalHost {
       private _portalHost: PortalHost,
       private _pane: HTMLElement,
       private _state: OverlayState,
-      private _ngZone: NgZone) { }
+      private _ngZone: NgZone) {}
 
   attach(portal: Portal<any>): any {
     if (this._state.hasBackdrop) {

--- a/src/lib/core/overlay/overlay.ts
+++ b/src/lib/core/overlay/overlay.ts
@@ -42,7 +42,16 @@ export class Overlay {
    * @returns A reference to the created overlay.
    */
   create(state: OverlayState = defaultState): OverlayRef {
-    return this._createOverlayRef(this._createPaneElement(), state);
+    let elements = this._createPaneElements();
+    let portalHost = new DomPortalHost(
+      elements.host,
+      this._componentFactoryResolver,
+      this._appRef,
+      this._injector,
+      elements.wrapper
+    );
+
+    return new OverlayRef(portalHost, elements.host, state, this._ngZone);
   }
 
   /**
@@ -57,33 +66,22 @@ export class Overlay {
    * Creates the DOM element for an overlay and appends it to the overlay container.
    * @returns Promise resolving to the created element.
    */
-  private _createPaneElement(): HTMLElement {
+  private _createPaneElements(): { wrapper: HTMLElement, host: HTMLElement } {
+    let paneWrapper = document.createElement('div');
     let pane = document.createElement('div');
-    pane.id = `md-overlay-${nextUniqueId++}`;
+
+    paneWrapper.classList.add('md-overlay-pane-wrapper');
     pane.classList.add('md-overlay-pane');
 
-    this._overlayContainer.getContainerElement().appendChild(pane);
+    paneWrapper.id = `md-overlay-${nextUniqueId++}`;
+    paneWrapper.appendChild(pane);
 
-    return pane;
-  }
+    this._overlayContainer.getContainerElement().appendChild(paneWrapper);
 
-  /**
-   * Create a DomPortalHost into which the overlay content can be loaded.
-   * @param pane The DOM element to turn into a portal host.
-   * @returns A portal host for the given DOM element.
-   */
-  private _createPortalHost(pane: HTMLElement): DomPortalHost {
-    return new DomPortalHost(pane, this._componentFactoryResolver, this._appRef, this._injector);
-  }
-
-  /**
-   * Creates an OverlayRef for an overlay in the given DOM element.
-   * @param pane DOM element for the overlay
-   * @param state
-   * @returns {OverlayRef}
-   */
-  private _createOverlayRef(pane: HTMLElement, state: OverlayState): OverlayRef {
-    return new OverlayRef(this._createPortalHost(pane), pane, state, this._ngZone);
+    return {
+      wrapper: paneWrapper,
+      host: pane
+    };
   }
 }
 

--- a/src/lib/core/overlay/position/global-position-strategy.ts
+++ b/src/lib/core/overlay/position/global-position-strategy.ts
@@ -1,4 +1,3 @@
-import {applyCssTransform} from '../../style/apply-transform';
 import {PositionStrategy} from './position-strategy';
 
 
@@ -7,59 +6,43 @@ import {PositionStrategy} from './position-strategy';
  * explicit position relative to the browser's viewport.
  */
 export class GlobalPositionStrategy implements PositionStrategy {
-  private _cssPosition: string = 'absolute';
-  private _top: string = '';
-  private _bottom: string = '';
-  private _left: string = '';
-  private _right: string = '';
-
-  /** Array of individual applications of translateX(). Currently only for centering. */
-  private _translateX: string[] = [];
-
-  /** Array of individual applications of translateY(). Currently only for centering. */
-  private _translateY: string[] = [];
-
-  /** Sets the element to use CSS position: fixed */
-  fixed() {
-    this._cssPosition = 'fixed';
-    return this;
-  }
-
-  /** Sets the element to use CSS position: absolute. This is the default. */
-  absolute() {
-    this._cssPosition = 'absolute';
-    return this;
-  }
+  private _cssPosition: string = 'static';
+  private _topOffset: string = '';
+  private _bottomOffset: string = '';
+  private _leftOffset: string = '';
+  private _rightOffset: string = '';
+  private _alignItems: string = '';
+  private _justifyContent: string = '';
 
   /** Sets the top position of the overlay. Clears any previously set vertical position. */
   top(value: string) {
-    this._bottom = '';
-    this._translateY = [];
-    this._top = value;
+    this._bottomOffset = '';
+    this._topOffset = value;
+    this._alignItems = 'flex-start';
     return this;
   }
 
   /** Sets the left position of the overlay. Clears any previously set horizontal position. */
   left(value: string) {
-    this._right = '';
-    this._translateX = [];
-    this._left = value;
+    this._rightOffset = '';
+    this._leftOffset = value;
+    this._justifyContent = 'flex-start';
     return this;
   }
 
   /** Sets the bottom position of the overlay. Clears any previously set vertical position. */
   bottom(value: string) {
-    this._top = '';
-    this._translateY = [];
-    this._bottom = value;
+    this._topOffset = '';
+    this._bottomOffset = value;
+    this._alignItems = 'flex-end';
     return this;
   }
 
   /** Sets the right position of the overlay. Clears any previously set horizontal position. */
   right(value: string) {
-    this._left = '';
-    this._translateX = [];
-    this._right = value;
+    this._leftOffset = '';
+    this._rightOffset = value;
+    this._justifyContent = 'flex-end';
     return this;
   }
 
@@ -68,9 +51,8 @@ export class GlobalPositionStrategy implements PositionStrategy {
    * Clears any previously set horizontal position.
    */
   centerHorizontally(offset = '0px') {
-    this._left = '50%';
-    this._right = '';
-    this._translateX = ['-50%', offset];
+    this.left(offset);
+    this._justifyContent = 'center';
     return this;
   }
 
@@ -79,9 +61,8 @@ export class GlobalPositionStrategy implements PositionStrategy {
    * Clears any previously set vertical position.
    */
   centerVertically(offset = '0px') {
-    this._top = '50%';
-    this._bottom = '';
-    this._translateY = ['-50%', offset];
+    this.top(offset);
+    this._alignItems = 'center';
     return this;
   }
 
@@ -90,24 +71,18 @@ export class GlobalPositionStrategy implements PositionStrategy {
    * TODO: internal
    */
   apply(element: HTMLElement): Promise<void> {
-    element.style.position = this._cssPosition;
-    element.style.top = this._top;
-    element.style.left = this._left;
-    element.style.bottom = this._bottom;
-    element.style.right = this._right;
+    let styles = element.style;
+    let parentStyles = (element.parentNode as HTMLElement).style;
 
-    // TODO(jelbourn): we don't want to always overwrite the transform property here,
-    // because it will need to be used for animations.
-    let tranlateX = this._reduceTranslateValues('translateX', this._translateX);
-    let translateY = this._reduceTranslateValues('translateY', this._translateY);
+    styles.position = this._cssPosition;
+    styles.marginTop = this._topOffset;
+    styles.marginLeft = this._leftOffset;
+    styles.marginBottom = this._bottomOffset;
+    styles.marginRight = this._rightOffset;
 
-    applyCssTransform(element, `${tranlateX} ${translateY}`);
+    parentStyles.justifyContent = this._justifyContent;
+    parentStyles.alignItems = this._alignItems;
 
     return Promise.resolve(null);
-  }
-
-  /** Reduce a list of translate values to a string that can be used in the transform property */
-  private _reduceTranslateValues(translateFn: string, values: string[]) {
-    return values.map(t => `${translateFn}(${t})`).join(' ');
   }
 }

--- a/src/lib/core/portal/dom-portal-host.ts
+++ b/src/lib/core/portal/dom-portal-host.ts
@@ -19,7 +19,8 @@ export class DomPortalHost extends BasePortalHost {
       private _hostDomElement: Element,
       private _componentFactoryResolver: ComponentFactoryResolver,
       private _appRef: ApplicationRef,
-      private _defaultInjector: Injector) {
+      private _defaultInjector: Injector,
+      private _hostWrapper?: Element) {
     super();
   }
 
@@ -101,8 +102,14 @@ export class DomPortalHost extends BasePortalHost {
 
   dispose(): void {
     super.dispose();
-    if (this._hostDomElement.parentNode != null) {
-      this._hostDomElement.parentNode.removeChild(this._hostDomElement);
+    this._removeNode(this._hostWrapper);
+    this._removeNode(this._hostDomElement);
+  }
+
+  /** Safely removes a node from the DOM. */
+  private _removeNode(node: Element) {
+    if (node && node.parentNode != null) {
+      node.parentNode.removeChild(node);
     }
   }
 

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -123,8 +123,8 @@ export class MdDialog {
     state.hasBackdrop = true;
     state.positionStrategy = this._overlay.position()
         .global()
-        .centerHorizontally()
-        .centerVertically();
+        .centerVertically()
+        .centerHorizontally();
 
     return state;
   }

--- a/src/lib/snack-bar/snack-bar.ts
+++ b/src/lib/snack-bar/snack-bar.ts
@@ -120,7 +120,6 @@ export class MdSnackBar {
   private _createOverlay(): OverlayRef {
     let state = new OverlayState();
     state.positionStrategy = this._overlay.position().global()
-        .fixed()
         .centerHorizontally()
         .bottom('0');
     return this._overlay.create(state);


### PR DESCRIPTION
This is a proof-of-concept for using flexbox to position global overlays (e.g. `dialog` and `snack-bar`) with flexbox. The main advantage with this approach is that it allows for automatic centering without subpixel rendering issues. A few notes:

* In order to prevent the changes to the global position strategy from interfering with other overlays that may get positioned in the same container, I've had to change up the DOM structure a little. In `master`, the DOM looks like `.md-overlay-container > .md-overlay-pane`, whereas these changes switch it to `.md-overlay-container > .md-overlay-pane-wrapper > .md-overlay-pane`. The flexbox properties are applied to the `md-overlay-pane-wrapper`.
* Since the DOM was changed, I've added a `_hostWrapper` property to the `DomPortalHost`. This is necessary in order to be able to clean up when closing. There's probably a nicer way of doing it, but I wanted to keep the changes as small as possible.
* Due to some centering issues in Firefox and IE, I've switched the top/bottom/left/right offsets to be done with `margin` and the flexbox properties. This works, however percentage-based offsets won't work as expected since now they're based on the element's size, instead of the viewport.