### PR TITLE
proposal(select): avoid excessive getBoundingClientRect calls

### DIFF
--- a/src/lib/core/overlay/overlay-directives.ts
+++ b/src/lib/core/overlay/overlay-directives.ts
@@ -34,6 +34,7 @@ let defaultPositionList = [
       {overlayX: 'start', overlayY: 'bottom'}),
 ];
 
+const MATCH_ORIGIN = 'match-origin';
 
 /**
  * Directive applied to an element to make it usable as an origin for an Overlay using a
@@ -171,13 +172,27 @@ export class ConnectedOverlayDirective implements OnDestroy {
   /** Builds the overlay config based on the directive's inputs */
   private _buildConfig(): OverlayState {
     let overlayConfig = new OverlayState();
+    let width = this.width;
+    let height = this.height;
 
-    if (this.width || this.width === 0) {
-      overlayConfig.width = this.width;
+    if (width === MATCH_ORIGIN || height === MATCH_ORIGIN) {
+      let clientRect: ClientRect = this.origin.elementRef.nativeElement.getBoundingClientRect();
+
+      if (width === MATCH_ORIGIN) {
+        width = clientRect.width;
+      }
+
+      if (height === MATCH_ORIGIN) {
+        height = clientRect.height;
+      }
     }
 
-    if (this.height || this.height === 0) {
-      overlayConfig.height = this.height;
+    if (width || width === 0) {
+      overlayConfig.width = width;
+    }
+
+    if (height || height === 0) {
+      overlayConfig.height = height;
     }
 
     overlayConfig.hasBackdrop = this.hasBackdrop;

--- a/src/lib/select/select.html
+++ b/src/lib/select/select.html
@@ -5,7 +5,7 @@
 </div>
 
 <template connected-overlay [origin]="origin"  [open]="panelOpen" hasBackdrop (backdropClick)="close()"
-  backdropClass="md-overlay-transparent-backdrop" [positions]="_positions" [width]="_getWidth()"
+  backdropClass="md-overlay-transparent-backdrop" [positions]="_positions" width="match-origin"
   [offsetY]="_offsetY" [offsetX]="_offsetX" (attach)="_setScrollTop()">
   <div class="md-select-panel" [@transformPanel]="'showing'" (@transformPanel.done)="_onPanelDone()"
     (keydown)="_keyManager.onKeydown($event)" [style.transformOrigin]="_transformOrigin">

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -293,13 +293,6 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
     return this._dir ? this._dir.value === 'rtl' : false;
   }
 
-  /** The width of the trigger element. This is necessary to match
-   * the overlay width to the trigger width.
-   */
-  _getWidth(): number {
-    return this._getTriggerRect().width;
-  }
-
   /** The animation state of the placeholder. */
   _getPlaceholderState(): string {
     if (this.panelOpen || this.selected) {


### PR DESCRIPTION
Currently `md-select` passes the width of it's trigger element to it's overlay via a data binding. The data binding gets updated every time the change detection runs, which means that it'll run `getBoundingClientRect` on pretty much any interaction with the page. This could cause performance issues in the future, especially on slower devices and more complex pages since every call to `getBoundingClientRect` causes a reflow.

This is a proposal to add a `match-origin` option to the `connected-overlay` directive. This option will make the overlay match it's origin's width/height and will only call `getBoundingClientRect` once when setting up the overlay.

The problem can alternatively be worked around with the following, however both approaches have their issues:
* Change the binding to `paneOpen ? _getWidth() : 0` - This works and avoids most of the `getBoundingClientRect` calls, but it looks weird and `getBoundingClientRect` still gets called for every change detection while the select is open.
* Pass in an observable to the `width` binding - This also works, but it ends up being inconvenient to have to deal with a type of `number | string | Observable` in the overlay directive.