### PR TITLE
proposal: useCapture for clicking outside overlays

### DIFF
--- a/e2e/components/overlay-e2e.spec.ts
+++ b/e2e/components/overlay-e2e.spec.ts
@@ -1,0 +1,41 @@
+import {browser, by, element, Key} from 'protractor';
+import {
+  expectToExist,
+  expectFocusOn,
+  pressKeys,
+  clickElementAtPoint,
+  waitForElement,
+} from '../util/index';
+
+describe('overlay', () => {
+  beforeEach(() => browser.get('/overlay'));
+
+  it('should open a connected overlay', () => {
+    element(by.id('connected-overlay-button')).click();
+    expectToExist('#connected-overlay');
+  });
+
+  it('should not close when clicking inside the overlay', () => {
+    element(by.id('connected-overlay-button')).click();
+    expectToExist('#connected-overlay');
+
+    element(by.id('connected-overlay-inner-button')).click();
+    expectToExist('#connected-overlay');
+  });
+
+  it('should close a connected overlay when clicking outside', () => {
+    element(by.id('connected-overlay-button')).click();
+    expectToExist('#connected-overlay');
+
+    element(by.id('regular-button')).click();
+    expectToExist('#connected-overlay', false);
+  });
+
+  it('should close the overlay when clicking on an element that stops event propagation', () => {
+    element(by.id('connected-overlay-button')).click();
+    expectToExist('#connected-overlay');
+
+    element(by.id('stops-propagation')).click();
+    expectToExist('#connected-overlay', false);
+  });
+});

--- a/src/cdk/overlay/overlay-directives.spec.ts
+++ b/src/cdk/overlay/overlay-directives.spec.ts
@@ -247,7 +247,7 @@ describe('Overlay directives', () => {
   });
 
   describe('outputs', () => {
-    it('should emit backdropClick appropriately', () => {
+    it('should emit outsideClick appropriately', () => {
       fixture.componentInstance.hasBackdrop = true;
       fixture.componentInstance.isOpen = true;
       fixture.detectChanges();
@@ -257,7 +257,7 @@ describe('Overlay directives', () => {
       backdrop.click();
       fixture.detectChanges();
 
-      expect(fixture.componentInstance.backdropClicked).toBe(true);
+      expect(fixture.componentInstance.clickedOutside).toBe(true);
     });
 
     it('should emit positionChange appropriately', () => {
@@ -300,7 +300,7 @@ describe('Overlay directives', () => {
   <ng-template cdk-connected-overlay [open]="isOpen" [width]="width" [height]="height"
             [origin]="trigger"
             [hasBackdrop]="hasBackdrop" backdropClass="mat-test-class"
-            (backdropClick)="backdropClicked=true" [offsetX]="offsetX" [offsetY]="offsetY"
+            (outsideClick)="clickedOutside=true" [offsetX]="offsetX" [offsetY]="offsetY"
             (positionChange)="positionChangeHandler($event)" (attach)="attachHandler()"
             (detach)="detachHandler()" [minWidth]="minWidth" [minHeight]="minHeight">
     <p>Menu content</p>
@@ -315,7 +315,7 @@ class ConnectedOverlayDirectiveTest {
   offsetX: number = 0;
   offsetY: number = 0;
   hasBackdrop: boolean;
-  backdropClicked = false;
+  clickedOutside = false;
   positionChangeHandler = jasmine.createSpy('positionChangeHandler');
   attachHandler = jasmine.createSpy('attachHandler').and.callFake(() => {
     this.attachResult =

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -95,7 +95,7 @@ export class ConnectedOverlayDirective implements OnDestroy, OnChanges {
   private _overlayRef: OverlayRef;
   private _templatePortal: TemplatePortal<any>;
   private _hasBackdrop = false;
-  private _backdropSubscription = Subscription.EMPTY;
+  private _outsideClickSubscription = Subscription.EMPTY;
   private _positionSubscription = Subscription.EMPTY;
   private _offsetX: number = 0;
   private _offsetY: number = 0;
@@ -217,8 +217,8 @@ export class ConnectedOverlayDirective implements OnDestroy, OnChanges {
   get _deprecatedHasBackdrop() { return this.hasBackdrop; }
   set _deprecatedHasBackdrop(_hasBackdrop: any) { this.hasBackdrop = _hasBackdrop; }
 
-  /** Event emitted when the backdrop is clicked. */
-  @Output() backdropClick = new EventEmitter<void>();
+  /** Event emitted when the user clicks outside the overlay. */
+  @Output() outsideClick = new EventEmitter<void>();
 
   /** Event emitted when the position has changed. */
   @Output() positionChange = new EventEmitter<ConnectedOverlayPositionChange>();
@@ -330,7 +330,7 @@ export class ConnectedOverlayDirective implements OnDestroy, OnChanges {
         strategy.onPositionChange.subscribe(pos => this.positionChange.emit(pos));
   }
 
-  /** Attaches the overlay and subscribes to backdrop clicks if backdrop exists */
+  /** Attaches the overlay. */
   private _attachOverlay() {
     if (!this._overlayRef) {
       this._createOverlay();
@@ -345,21 +345,19 @@ export class ConnectedOverlayDirective implements OnDestroy, OnChanges {
       this.attach.emit();
     }
 
-    if (this.hasBackdrop) {
-      this._backdropSubscription = this._overlayRef.backdropClick().subscribe(() => {
-        this.backdropClick.emit();
-      });
-    }
+    this._outsideClickSubscription = this._overlayRef.outsideClick().subscribe(() => {
+      this.outsideClick.emit();
+    });
   }
 
-  /** Detaches the overlay and unsubscribes to backdrop clicks if backdrop exists */
+  /** Detaches the overlay. */
   private _detachOverlay() {
     if (this._overlayRef) {
       this._overlayRef.detach();
       this.detach.emit();
     }
 
-    this._backdropSubscription.unsubscribe();
+    this._outsideClickSubscription.unsubscribe();
     this._escapeListener();
   }
 
@@ -369,7 +367,7 @@ export class ConnectedOverlayDirective implements OnDestroy, OnChanges {
       this._overlayRef.dispose();
     }
 
-    this._backdropSubscription.unsubscribe();
+    this._outsideClickSubscription.unsubscribe();
     this._positionSubscription.unsubscribe();
     this._escapeListener();
   }

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -15,6 +15,7 @@ import {
   PositionStrategy,
   ScrollStrategy,
 } from './index';
+import {dispatchMouseEvent} from '@angular/cdk/testing';
 
 
 describe('Overlay', () => {
@@ -319,6 +320,40 @@ describe('Overlay', () => {
     });
   });
 
+  describe('clicking outside', () => {
+    let config: OverlayConfig;
+
+    beforeEach(() => {
+      config = new OverlayConfig();
+      config.hasBackdrop = false;
+    });
+
+    it('should close the overlay when clicking outside', () => {
+      const overlayRef = overlay.create(config);
+      overlayRef.attach(componentPortal);
+      viewContainerFixture.detectChanges();
+
+      const outsideClickHandler = jasmine.createSpy('outslideClickHandler');
+      overlayRef.outsideClick().subscribe(outsideClickHandler);
+
+      dispatchMouseEvent(document, 'click');
+      expect(outsideClickHandler).toHaveBeenCalled();
+    });
+
+    it('should complete the outside click stream once the overlay is destroyed', () => {
+      const overlayRef = overlay.create(config);
+      overlayRef.attach(componentPortal);
+      viewContainerFixture.detectChanges();
+
+      const completeHandler = jasmine.createSpy('outsideClick complete handler');
+      overlayRef.outsideClick().subscribe(undefined, undefined, completeHandler);
+      overlayRef.dispose();
+
+      expect(completeHandler).toHaveBeenCalled();
+    });
+
+  });
+
   describe('backdrop', () => {
     let config: OverlayConfig;
 
@@ -336,11 +371,11 @@ describe('Overlay', () => {
       expect(backdrop).toBeTruthy();
       expect(backdrop.classList).not.toContain('cdk-overlay-backdrop-showing');
 
-      let backdropClickHandler = jasmine.createSpy('backdropClickHander');
-      overlayRef.backdropClick().subscribe(backdropClickHandler);
+      let outsideClickHandler = jasmine.createSpy('outslideClickHandler');
+      overlayRef.outsideClick().subscribe(outsideClickHandler);
 
       backdrop.click();
-      expect(backdropClickHandler).toHaveBeenCalled();
+      expect(outsideClickHandler).toHaveBeenCalled();
     });
 
     it('should complete the backdrop click stream once the overlay is destroyed', () => {
@@ -351,7 +386,7 @@ describe('Overlay', () => {
 
       let completeHandler = jasmine.createSpy('backdrop complete handler');
 
-      overlayRef.backdropClick().subscribe(undefined, undefined, completeHandler);
+      overlayRef.outsideClick().subscribe(undefined, undefined, completeHandler);
       overlayRef.dispose();
 
       expect(completeHandler).toHaveBeenCalled();

--- a/src/cdk/rxjs/rx-operators.ts
+++ b/src/cdk/rxjs/rx-operators.ts
@@ -22,6 +22,7 @@ import {startWith as startWithOperator} from 'rxjs/operator/startWith';
 import {debounceTime as debounceTimeOperator} from 'rxjs/operator/debounceTime';
 import {auditTime as auditTimeOperator} from 'rxjs/operator/auditTime';
 import {takeUntil as takeUntilOperator} from 'rxjs/operator/takeUntil';
+import {pairwise as pairwiseOperator} from 'rxjs/operator/pairwise';
 
 /**
  * Represents a strongly-typed chain of RxJS operators.
@@ -71,6 +72,8 @@ export interface StrictRxChain<T> {
 
   call(operator: takeUntilOperatorType<T>, notifier: Observable<any>): StrictRxChain<T>;
 
+  call(operator: pairwiseOperatorType<T>): StrictRxChain<[T, T]>;
+
   subscribe(fn: (t: T) => void): Subscription;
 
   result(): Observable<T>;
@@ -89,6 +92,7 @@ export class StartWithBrand { private _; }
 export class DebounceTimeBrand { private _; }
 export class AuditTimeBrand { private _; }
 export class TakeUntilBrand { private _; }
+export class PairwiseBrand { private _; }
 /* tslint:enable:no-unused-variable */
 
 
@@ -104,6 +108,7 @@ export type startWithOperatorType<T> = typeof startWithOperator & StartWithBrand
 export type debounceTimeOperatorType<T> = typeof debounceTimeOperator & DebounceTimeBrand;
 export type auditTimeOperatorType<T> = typeof auditTimeOperator & AuditTimeBrand;
 export type takeUntilOperatorType<T> = typeof takeUntilOperator & TakeUntilBrand;
+export type pairwiseOperatorType<T> = typeof pairwiseOperator & PairwiseBrand;
 
 // We add `Function` to the type intersection to make this nomically different from
 // `finallyOperatorType` while still being structurally the same. Without this, TypeScript tries to
@@ -123,3 +128,4 @@ export const debounceTime =
     debounceTimeOperator as typeof debounceTimeOperator & DebounceTimeBrand & Function;
 export const auditTime = auditTimeOperator as typeof auditTimeOperator & AuditTimeBrand & Function;
 export const takeUntil = takeUntilOperator as typeof takeUntilOperator & TakeUntilBrand & Function;
+export const pairwise = pairwiseOperator as typeof pairwiseOperator & PairwiseBrand & Function;

--- a/src/demo-app/overlay/overlay-demo.html
+++ b/src/demo-app/overlay/overlay-demo.html
@@ -20,7 +20,7 @@
 </button>
 
 <ng-template cdk-connected-overlay [origin]="trigger" [width]="500" hasBackdrop [open]="isMenuOpen"
-  (backdropClick)="isMenuOpen=false">
+  (outsideClick)="isMenuOpen=false">
   <div style="background-color: mediumpurple" >
     This is the menu panel.
   </div>

--- a/src/demo-app/overlay/overlay-demo.ts
+++ b/src/demo-app/overlay/overlay-demo.ts
@@ -95,13 +95,12 @@ export class OverlayDemo {
   openPanelWithBackdrop() {
     let config = new OverlayConfig({
       hasBackdrop: true,
-      backdropClass: 'cdk-overlay-transparent-backdrop',
       positionStrategy: this.overlay.position().global().centerHorizontally()
     });
 
     let overlayRef = this.overlay.create(config);
     overlayRef.attach(this.templatePortals.first);
-    overlayRef.backdropClick().subscribe(() => overlayRef.detach());
+    overlayRef.outsideClick().subscribe(() => overlayRef.detach());
   }
 
 }

--- a/src/e2e-app/e2e-app-module.ts
+++ b/src/e2e-app/e2e-app-module.ts
@@ -19,6 +19,7 @@ import {SlideToggleE2E} from './slide-toggle/slide-toggle-e2e';
 import {InputE2E} from './input/input-e2e';
 import {SidenavE2E} from './sidenav/sidenav-e2e';
 import {BlockScrollStrategyE2E} from './block-scroll-strategy/block-scroll-strategy-e2e';
+import {OverlayE2E} from './overlay/overlay-e2e';
 import {
   MatButtonModule,
   MatCheckboxModule,
@@ -96,7 +97,8 @@ export class E2eMaterialModule {}
     SlideToggleE2E,
     TestDialog,
     TestDialogFullScreen,
-    BlockScrollStrategyE2E
+    BlockScrollStrategyE2E,
+    OverlayE2E,
   ],
   bootstrap: [E2EApp],
   providers: [

--- a/src/e2e-app/e2e-app/e2e-app.html
+++ b/src/e2e-app/e2e-app/e2e-app.html
@@ -22,6 +22,7 @@
   <a mat-list-item [routerLink]="['tabs']">Tabs</a>
   <a mat-list-item [routerLink]="['cards']">Cards</a>
   <a mat-list-item [routerLink]="['toolbar']">Toolbar</a>
+  <a mat-list-item [routerLink]="['overlay']">Overlay</a>
 </mat-nav-list>
 
 <main>

--- a/src/e2e-app/e2e-app/routes.ts
+++ b/src/e2e-app/e2e-app/routes.ts
@@ -15,6 +15,7 @@ import {FullscreenE2E} from '../fullscreen/fullscreen-e2e';
 import {InputE2E} from '../input/input-e2e';
 import {SidenavE2E} from '../sidenav/sidenav-e2e';
 import {BlockScrollStrategyE2E} from '../block-scroll-strategy/block-scroll-strategy-e2e';
+import {OverlayE2E} from '../overlay/overlay-e2e';
 import {
   CardFancyExample,
   ListOverviewExample,
@@ -47,4 +48,5 @@ export const E2E_APP_ROUTES: Routes = [
   {path: 'tabs', component: BasicTabs},
   {path: 'cards', component: CardFancyExample},
   {path: 'toolbar', component: ToolbarMultirowExample},
+  {path: 'overlay', component: OverlayE2E},
 ];

--- a/src/e2e-app/overlay/overlay-e2e.css
+++ b/src/e2e-app/overlay/overlay-e2e.css
@@ -1,0 +1,5 @@
+#connected-overlay {
+  background: pink;
+  padding: 10px;
+  width: 200px;
+}

--- a/src/e2e-app/overlay/overlay-e2e.html
+++ b/src/e2e-app/overlay/overlay-e2e.html
@@ -1,0 +1,13 @@
+<p>
+  <button id="regular-button">Regular button</button>
+  <button id="stops-propagation" (click)="$event.stopPropagation()">Stops propagation</button>
+</p>
+
+<button #origin id="connected-overlay-button" (click)="open()">Open connected overlay</button>
+
+<ng-template #connectedOverlay>
+  <div id="connected-overlay">
+    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, unde.</p>
+    <button id="connected-overlay-inner-button">Does nothing</button>
+  </div>
+</ng-template>

--- a/src/e2e-app/overlay/overlay-e2e.ts
+++ b/src/e2e-app/overlay/overlay-e2e.ts
@@ -1,0 +1,37 @@
+import {
+  Component,
+  ViewChild,
+  ElementRef,
+  ViewContainerRef,
+  TemplateRef,
+  ViewEncapsulation,
+} from '@angular/core';
+import {Overlay, OverlayConfig} from '@angular/cdk/overlay';
+import {TemplatePortal} from '@angular/cdk/portal';
+
+@Component({
+  moduleId: module.id,
+  selector: 'overlay-e2e',
+  templateUrl: 'overlay-e2e.html',
+  styleUrls: ['overlay-e2e.css'],
+  encapsulation: ViewEncapsulation.None,
+})
+export class OverlayE2E {
+  @ViewChild('origin') origin: ElementRef;
+  @ViewChild('connectedOverlay') connectedOverlay: TemplateRef<any>;
+
+  constructor(private _overlay: Overlay, private _viewContainerRef: ViewContainerRef) { }
+
+  open() {
+    const strategy = this._overlay.position()
+      .connectedTo(this.origin,
+        {originX: 'start', originY: 'bottom'},
+        {overlayX: 'start', overlayY: 'top'});
+
+    const config = new OverlayConfig({positionStrategy: strategy});
+    const overlayRef = this._overlay.create(config);
+
+    overlayRef.attach(new TemplatePortal(this.connectedOverlay, this._viewContainerRef));
+    overlayRef.outsideClick().subscribe(() => overlayRef.dispose());
+  }
+}

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -328,15 +328,13 @@ export class MatDatepicker<D> implements OnDestroy {
       });
     }
 
-    this._popupRef.backdropClick().subscribe(() => this.close());
+    this._popupRef.outsideClick().subscribe(() => this.close());
   }
 
   /** Create the popup. */
   private _createPopup(): void {
     const overlayConfig = new OverlayConfig({
       positionStrategy: this._createPopupPositionStrategy(),
-      hasBackdrop: true,
-      backdropClass: 'mat-overlay-transparent-backdrop',
       direction: this._dir ? this._dir.value : 'ltr',
       scrollStrategy: this._scrollStrategy()
     });

--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -111,8 +111,8 @@ export class MatDialogRef<T> {
   /**
    * Gets an observable that emits when the overlay's backdrop has been clicked.
    */
-  backdropClick(): Observable<void> {
-    return this._overlayRef.backdropClick();
+  backdropClick(): Observable<null> {
+    return this._overlayRef.outsideClick();
   }
 
   /**

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -235,7 +235,7 @@ export class MatDialog {
 
     // When the dialog backdrop is clicked, we want to close it.
     if (config.hasBackdrop) {
-      overlayRef.backdropClick().subscribe(() => {
+      overlayRef.outsideClick().subscribe(() => {
         if (!dialogRef.disableClose) {
           dialogRef.close();
         }

--- a/src/lib/select/select.html
+++ b/src/lib/select/select.html
@@ -21,15 +21,13 @@
 
 <ng-template
   cdk-connected-overlay
-  hasBackdrop
-  backdropClass="cdk-overlay-transparent-backdrop"
   [scrollStrategy]="_scrollStrategy"
   [origin]="origin"
   [open]="panelOpen"
   [positions]="_positions"
   [minWidth]="_triggerRect?.width"
   [offsetY]="_offsetY"
-  (backdropClick)="close()"
+  (outsideClick)="close()"
   (attach)="_onAttached()"
   (detach)="close()">
 

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -3,7 +3,12 @@ import {DOWN_ARROW, END, ENTER, HOME, SPACE, TAB, UP_ARROW} from '@angular/cdk/k
 import {OverlayContainer} from '@angular/cdk/overlay';
 import {Platform} from '@angular/cdk/platform';
 import {ScrollDispatcher, ViewportRuler} from '@angular/cdk/scrolling';
-import {dispatchFakeEvent, dispatchKeyboardEvent, wrappedErrorMessage} from '@angular/cdk/testing';
+import {
+  dispatchFakeEvent,
+  dispatchMouseEvent,
+  dispatchKeyboardEvent,
+  wrappedErrorMessage,
+} from '@angular/cdk/testing';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -185,10 +190,7 @@ describe('MatSelect', () => {
       trigger.click();
       fixture.detectChanges();
 
-      const backdrop =
-          overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
-
-      backdrop.click();
+      dispatchMouseEvent(document, 'click');
       fixture.detectChanges();
 
       fixture.whenStable().then(() => {
@@ -665,9 +667,7 @@ describe('MatSelect', () => {
       expect(fixture.componentInstance.control.touched)
         .toEqual(false, `Expected the control to stay untouched when menu opened.`);
 
-      const backdrop =
-        overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
-      backdrop.click();
+      dispatchMouseEvent(document, 'click');
       dispatchFakeEvent(trigger, 'blur');
       fixture.detectChanges();
       expect(fixture.componentInstance.control.touched)
@@ -1000,9 +1000,7 @@ describe('MatSelect', () => {
       expect(formField.classList.contains('mat-form-field-should-float'))
           .toBe(true, 'Expected placeholder to animate up to floating position.');
 
-      const backdrop =
-        overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
-      backdrop.click();
+      fixture.componentInstance.select.close();
       fixture.detectChanges();
 
       expect(formField.classList.contains('mat-form-field-should-float'))
@@ -2191,9 +2189,7 @@ describe('MatSelect', () => {
         expect(selects[0].nativeElement.getAttribute('aria-owns'))
             .toContain(options[1].id, `Expected aria-owns to contain IDs of its child options.`);
 
-        const backdrop =
-            overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
-        backdrop.click();
+        dispatchMouseEvent(document, 'click');
         fixture.detectChanges();
 
         fixture.whenStable().then(() => {
@@ -2217,9 +2213,7 @@ describe('MatSelect', () => {
             .toContain('mat-option', `Expected option ID to have the correct prefix.`);
         expect(options[0].id).not.toEqual(options[1].id, `Expected option IDs to be unique.`);
 
-        const backdrop =
-            overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
-        backdrop.click();
+        dispatchMouseEvent(document, 'click');
         fixture.detectChanges();
 
         fixture.whenStable().then(() => {

--- a/src/lib/sidenav/drawer-container.html
+++ b/src/lib/sidenav/drawer-container.html
@@ -5,6 +5,6 @@
 
 <ng-content select="mat-drawer-content">
 </ng-content>
-<mat-drawer-content *ngIf="!_content">
+<mat-drawer-content *ngIf="!_content" cdk-scrollable>
   <ng-content></ng-content>
 </mat-drawer-content>

--- a/src/lib/sidenav/sidenav-container.html
+++ b/src/lib/sidenav/sidenav-container.html
@@ -5,6 +5,6 @@
 
 <ng-content select="mat-sidenav-content">
 </ng-content>
-<mat-sidenav-content *ngIf="!_content">
+<mat-sidenav-content *ngIf="!_content" cdk-scrollable>
   <ng-content></ng-content>
 </mat-sidenav-content>

--- a/tools/gulp/util/task_helpers.ts
+++ b/tools/gulp/util/task_helpers.ts
@@ -134,6 +134,7 @@ export function serverTask(packagePath: string, livereload = true) {
     gulpConnect.server({
       root: projectDir,
       livereload: livereload,
+      host: '192.168.1.46',
       port: 4200,
       middleware: () => {
         return [httpRewrite.getMiddleware([

--- a/tools/package-tools/rollup-globals.ts
+++ b/tools/package-tools/rollup-globals.ts
@@ -80,6 +80,7 @@ export const rollupGlobals = {
   'rxjs/operator/switchMap': 'Rx.Observable.prototype',
   'rxjs/operator/takeUntil': 'Rx.Observable.prototype',
   'rxjs/operator/toPromise': 'Rx.Observable.prototype',
+  'rxjs/operator/pairwise': 'Rx.Observable.prototype',
 
   'rxjs/add/observable/merge': 'Rx.Observable',
   'rxjs/add/observable/fromEvent': 'Rx.Observable',


### PR DESCRIPTION
This is a proof-of-concept for using a global click listener with `useCapture` to determine whether the user clicked outside an overlay. These are some pros and cons of the approach after trying to implement it into all of the components:

## Pros
1. The transparent overlay no longer blocks scrolling inside non-body elements (e.g. a sidenav container).
2. We don't have to add and manage an extra DOM element for the backdrop.
3. The user can click directly into another element, as opposed to having to click once to close the overlay and once more on the element.

## Cons
1. The document `click` handler doesn't fire on iOS, unless the user tapped on a clickable element (an element with `cursor: pointer`). To get around this I made a synthetic `tap` stream that seems to work pretty well, but makes some assumptions. An interaction is considered a "tap" if there was a `touchstart` event, followed by a `touchend`, without a `touchmove` inbetween.
2. Since we're enabling `useCapture` it means that the document click handler will fire before any events on children. This means that clicking on an overlay trigger while the overlay is open will close the overlay and immediately reopen it. It can be worked around with another `filter` before the `outsideClick` stream.
3. Some of the more advanced cases become really difficult (namely nested menus), because the document click handler now fires before all other handlers and we don't have the opportunity to block it. We could potentially fall back to the backdrop behavior only for those cases, but that'll add another code path and make things inconsistent.

cc @jelbourn