### PR TITLE
Test failure diagnosis

### DIFF
--- a/src/cdk/overlay/overlay-directives.spec.ts
+++ b/src/cdk/overlay/overlay-directives.spec.ts
@@ -8,13 +8,21 @@ import {
   dispatchEvent,
 } from '@angular/cdk/testing/private';
 import {ESCAPE, A} from '@angular/cdk/keycodes';
-import {Overlay, CdkConnectedOverlay, OverlayModule, CdkOverlayOrigin} from './index';
+import {
+  Overlay,
+  CdkConnectedOverlay,
+  OverlayModule,
+  CdkOverlayOrigin,
+  ScrollDispatcher,
+  ScrollStrategy,
+} from './index';
 import {OverlayContainer} from './overlay-container';
 import {
   ConnectedOverlayPositionChange,
   ConnectionPositionPair,
 } from './position/connected-position';
 import {FlexibleConnectedPositionStrategy} from './position/flexible-connected-position-strategy';
+import {Subject} from 'rxjs';
 
 
 describe('Overlay directives', () => {
@@ -23,12 +31,17 @@ describe('Overlay directives', () => {
   let overlayContainerElement: HTMLElement;
   let fixture: ComponentFixture<ConnectedOverlayDirectiveTest>;
   let dir: {value: string};
+  let scrolledSubject = new Subject();
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [OverlayModule],
       declarations: [ConnectedOverlayDirectiveTest, ConnectedOverlayPropertyInitOrder],
-      providers: [{provide: Directionality, useFactory: () => dir = {value: 'ltr'}}],
+      providers: [{provide: Directionality, useFactory: () => dir = {value: 'ltr'}},
+        {provide: ScrollDispatcher, useFactory: () => ({
+          scrolled: () => scrolledSubject.asObservable()
+        })}
+      ],
     });
   });
 
@@ -529,7 +542,7 @@ describe('Overlay directives', () => {
   });
 
   describe('outputs', () => {
-    it('should emit backdropClick appropriately', () => {
+    it('should emit when the backdrop was clicked', () => {
       fixture.componentInstance.hasBackdrop = true;
       fixture.componentInstance.isOpen = true;
       fixture.detectChanges();
@@ -543,7 +556,7 @@ describe('Overlay directives', () => {
           .toHaveBeenCalledWith(jasmine.any(MouseEvent));
     });
 
-    it('should emit positionChange appropriately', () => {
+    it('should emit when the position has changed', () => {
       expect(fixture.componentInstance.positionChangeHandler).not.toHaveBeenCalled();
       fixture.componentInstance.isOpen = true;
       fixture.detectChanges();
@@ -556,15 +569,24 @@ describe('Overlay directives', () => {
           .toBe(true, `Expected directive to emit an instance of ConnectedOverlayPositionChange.`);
     });
 
-    it('should emit attach and detach appropriately', () => {
+    it('should emit when attached', () => {
       expect(fixture.componentInstance.attachHandler).not.toHaveBeenCalled();
-      expect(fixture.componentInstance.detachHandler).not.toHaveBeenCalled();
       fixture.componentInstance.isOpen = true;
       fixture.detectChanges();
 
       expect(fixture.componentInstance.attachHandler).toHaveBeenCalled();
       expect(fixture.componentInstance.attachResult instanceof HTMLElement)
           .toBe(true, `Expected pane to be populated with HTML elements when attach was called.`);
+
+      fixture.componentInstance.isOpen = false;
+      fixture.detectChanges();
+    });
+
+    it('should emit when detached', () => {
+      expect(fixture.componentInstance.detachHandler).not.toHaveBeenCalled();
+      fixture.componentInstance.isOpen = true;
+      fixture.detectChanges();
+
       expect(fixture.componentInstance.detachHandler).not.toHaveBeenCalled();
 
       fixture.componentInstance.isOpen = false;
@@ -584,10 +606,23 @@ describe('Overlay directives', () => {
       expect(fixture.componentInstance.keydownHandler).toHaveBeenCalledWith(event);
     });
 
+    it('should emit when detached externally', () => {
+      expect(fixture.componentInstance.detachHandler).not.toHaveBeenCalled();
+      fixture.componentInstance.scrollStrategy = overlay.scrollStrategies.close();
+      fixture.componentInstance.isOpen = true;
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.detachHandler).not.toHaveBeenCalled();
+
+      scrolledSubject.next();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.detachHandler).toHaveBeenCalled();
+    });
+
   });
 
 });
-
 
 @Component({
   template: `
@@ -605,6 +640,7 @@ describe('Overlay directives', () => {
             [cdkConnectedOverlayFlexibleDimensions]="flexibleDimensions"
             [cdkConnectedOverlayGrowAfterOpen]="growAfterOpen"
             [cdkConnectedOverlayPush]="push"
+            [cdkConnectedOverlayScrollStrategy]="scrollStrategy"
             cdkConnectedOverlayBackdropClass="mat-test-class"
             cdkConnectedOverlayPanelClass="cdk-test-panel-class"
             (backdropClick)="backdropClickHandler($event)"
@@ -640,13 +676,14 @@ class ConnectedOverlayDirectiveTest {
   flexibleDimensions: boolean;
   growAfterOpen: boolean;
   push: boolean;
+  scrollStrategy: ScrollStrategy;
   backdropClickHandler = jasmine.createSpy('backdropClick handler');
   positionChangeHandler = jasmine.createSpy('positionChange handler');
   keydownHandler = jasmine.createSpy('keydown handler');
   positionOverrides: ConnectionPositionPair[];
   attachHandler = jasmine.createSpy('attachHandler').and.callFake(() => {
-    this.attachResult =
-        this.connectedOverlayDirective.overlayRef.overlayElement.querySelector('p') as HTMLElement;
+    const overlayElement = this.connectedOverlayDirective.overlayRef.overlayElement;
+    this.attachResult = overlayElement.querySelector('p') as HTMLElement;
   });
   detachHandler = jasmine.createSpy('detachHandler');
   attachResult: HTMLElement;

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -280,7 +280,8 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
     }
 
     this._overlayRef = this._overlay.create(this._buildConfig());
-
+    this._overlayRef.attachments().subscribe(() => this.attach.emit());
+    this._overlayRef.detachments().subscribe(() => this.detach.emit());
     this._overlayRef.keydownEvents().subscribe((event: KeyboardEvent) => {
       this.overlayKeydown.next(event);
 
@@ -373,7 +374,6 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
 
     if (!this._overlayRef.hasAttached()) {
       this._overlayRef.attach(this._templatePortal);
-      this.attach.emit();
     }
 
     if (this.hasBackdrop) {
@@ -389,7 +389,6 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
   private _detachOverlay() {
     if (this._overlayRef) {
       this._overlayRef.detach();
-      this.detach.emit();
     }
 
     this._backdropSubscription.unsubscribe();

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -246,6 +246,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
   }
 
   ngOnDestroy() {
+    console.log('CdkConnectedOverlay ngOnDestroy')
     if (this._overlayRef) {
       this._overlayRef.dispose();
     }

--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -523,6 +523,7 @@ export class MatFormField extends _MatFormFieldMixinBase
   /** Throws an error if the form field's control is missing. */
   protected _validateControlChild() {
     if (!this._control) {
+      console.log('Missing control error thrown');
       throw getMatFormFieldMissingControlError();
     }
   }

--- a/src/material/input/BUILD.bazel
+++ b/src/material/input/BUILD.bazel
@@ -47,6 +47,7 @@ ng_test_library(
         ":input",
         "//src/cdk/bidi",
         "//src/cdk/platform",
+        "//src/cdk/overlay",
         "//src/cdk/testing/private",
         "//src/material/core",
         "//src/material/form-field",


### PR DESCRIPTION
This contains a test that shows the failure we are encountering in Google. Due to overlay's detachment and subsequent `click` in the `CompWithOverlay` component, we are finding that change detection is run at a moment where, for some reason, `MatFormField` no longer detects that it contains a control.

When you run this test, you'll find that it passes. But the reason it passes is because it does not acknowledge the error from `MatFormField`. It is being eaten due to RxJS's error handling somewhere (I couldn't figure out where).

The reason this fails in Google is twofold:
1. All tests in Google still use RxJS's deprecated error handling, which meant that errors were handled synchronously. Our tests do not do this. In Google, https://github.com/ReactiveX/rxjs/blob/b280c879228a8d78a3bb52c487459abc1fee4e2b/src/internal/config.ts has the value of `useDeprecatedSynchronousErrorHandling` set to `true`, where ours is `false`.
2. All tests create the `ComponentFixture` with `ComponentFixtureAutoDetect` set to `true`. This (I assume) causes change detection to run more often, reducing the risk of errors from missing `flush` and `tick` calls. Our specs do not do this, but in this test I changed it to true to match Google.

If you run this test, check out the `console.log` to see that `MatFormField` throws an error during the test, but it never causes the test to fail.

This is the end of several dozen hours of investigating, so I think for now I'll pass this off to you for how we move forward. While it might be easy to say we can change the tests in Google, this is just one example of failures all boiling down to odd change detection. E.g. in one case the select fails to find options anymore.